### PR TITLE
Update ninja to include fortran support

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,16 +1,17 @@
 {% set version = "1.9.0" %}
+{% set archive_version = "28a7d1491367de7b39c854d166114f76d272f04f" %}
 
 package:
   name: ninja
   version: {{ version }}
 
 source:
-  fn: v{{ version }}.tar.gz
-  url: https://github.com/ninja-build/ninja/archive/v{{ version }}.tar.gz
-  sha256: 5d7ec75828f8d3fd1a0c2f31b5b0cea780cdfe1031359228c428c1a48bfcd5b9
+  fn: {{ archive_version }}.tar.gz
+  url: https://github.com/ninja-build/ninja/archive/{{ archive_version }}.tar.gz
+  sha256: ed625f642ea113299d42facacf90e3135b87d2f83c6ed1040b710b6afdbedc9d
 
 build:
-  number: 0
+  number: 1
   skip: true  # [win and vc!=14]
   ignore_run_exports:
     - vc


### PR DESCRIPTION
Checklist
* [x] Used a fork of the feedstock to propose changes
* [x] Bumped the build number (if the version is unchanged)
* [x] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/conda_smithy.html#how-to-re-render ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

List of changes since v1.9.0:

```
$ git shortlog v1.9.0..28a7d14 --no-merges
Brad King (20):
      ManifestParser: Fix typo {expectd => expected}
      Factor out a base class of ManifestParser
      Assert precondition in BuildStatus::BuildEdgeStarted
      Allow EdgeFinished and NodeFinished to fail with errors
      Teach FakeCommandRunner to support multiple active commands
      Factor out edge marking logic from Plan::AddSubTarget
      Factor out output edge ready check from Plan::NodeFinished
      Make a Builder optionally available to Plan
      Explicitly avoid repeat deps loading
      Add a parser for a new "dyndep" file format
      Add a "dyndep" reserved binding to the manifest format
      Teach DependencyScan to load a dyndep file
      Teach RecomputeDirty to load dyndep files that are ready
      Teach builder to load dyndep files when they are ready
      clean: remove unnecessary Cleaner constructor variant
      clean: remove outputs specified by dyndep files
      graph: load dyndep files
      query: load dyndep files for queried edges
      Document `dyndep` binding behavior and the dyndep file format
      Document example dyndep use cases

Graham Christensen (1):
      Docs: Make builds reproducible by generating the same IDs from the same inputs

Jan Niklas Hasse (5):
      Fix Fuchsia typo
      Take CPU set limitations into account when calculating processor count
      Remove trailing whitespace from all files
      Ignore .ccls-cache directory
      Fix UB "member call on null pointer of type 'DepsLog'", see #1248

Nicolas Despres (1):
      Resurrect the 'rules' tool.

ddrone (1):
      Update link to premake

goshhhy (1):
      make inline.sh more portable

jhuels (1):
      Feature/add term env dumb to win32 (#1550)
```